### PR TITLE
Adds check for canOpenURL on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,16 @@ A Flutter plugin to assist in leaving user reviews/ratings in Google Play Store 
 
 > *NOTE:* Please feel free to send a PR to add more functionalities.
 
+### iOS
 Thanks to [Edouard Marquez](https://github.com/g123k) for adding the iOS functionality.
+
+For iOS 9 and above, your `Info.plist` file  __MUST__ have the following:
+```
+<key>LSApplicationQueriesSchemes</key>
+<array>
+        <string>itms</string>
+</array>
+```
 
 ## Usage
 To use this plugin, add `launch_review` as a [dependency in your pubspec.yaml file](https://flutter.io/platform-plugins/).

--- a/ios/Classes/LaunchReviewPlugin.m
+++ b/ios/Classes/LaunchReviewPlugin.m
@@ -23,13 +23,16 @@
                                      details:nil]);
         } else {
             NSString *iTunesLink;
-
             if ([call.arguments[@"write_review"] boolValue]) {
               iTunesLink = [NSString stringWithFormat:@"itms-apps://itunes.apple.com/app/id%@?action=write-review", appId];
             } else {
               iTunesLink = [NSString stringWithFormat:@"itms-apps://itunes.apple.com/app/id%@", appId];
             }
-            [[UIApplication sharedApplication] openURL:[NSURL URLWithString:iTunesLink]];
+
+            NSURL* itunesURL = [NSURL URLWithString:iTunesLink];
+            if ([[UIApplication sharedApplication] canOpenURL:itunesURL]) {
+              [[UIApplication sharedApplication] openURL:itunesURL];
+            }
 
             result(nil);
         }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: launch_review
 description: A Flutter plugin to assist in leaving user reviews/ratings in Google Play Store and Apple App Store.
-version: 1.0.1
+version: 1.0.2
 author: Purusothaman Ramanujam <purushoth.r@gmail.com>
 homepage: https://github.com/purus/launch_review/
 


### PR DESCRIPTION
Hey, this was crashing during development (pre app store), on both iOS simulator, and iOS hardware.
Includes readme update about adding values to Info.plist for querying schemes.

Let me know what you think; thanks for this package!