### PR TITLE
iOS implementation improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,6 @@ A Flutter plugin to assist in leaving user reviews/ratings in Google Play Store 
 ### iOS
 Thanks to [Edouard Marquez](https://github.com/g123k) for adding the iOS functionality.
 
-For iOS 9 and above, your `Info.plist` file  __MUST__ have the following:
-```
-<key>LSApplicationQueriesSchemes</key>
-<array>
-        <string>itms</string>
-</array>
-```
-
 ## Usage
 To use this plugin, add `launch_review` as a [dependency in your pubspec.yaml file](https://flutter.io/platform-plugins/).
 

--- a/ios/Classes/LaunchReviewPlugin.m
+++ b/ios/Classes/LaunchReviewPlugin.m
@@ -24,9 +24,9 @@
         } else {
             NSString *iTunesLink;
             if ([call.arguments[@"write_review"] boolValue]) {
-              iTunesLink = [NSString stringWithFormat:@"https://itunes.apple.com/app/id%@?action=write-review", appId];
+              iTunesLink = [NSString stringWithFormat:@"https://apps.apple.com/app/id%@?action=write-review", appId];
             } else {
-              iTunesLink = [NSString stringWithFormat:@"https://itunes.apple.com/app/id%@", appId];
+              iTunesLink = [NSString stringWithFormat:@"https://apps.apple.com/app/id%@", appId];
             }
 
             NSURL* itunesURL = [NSURL URLWithString:iTunesLink];

--- a/ios/Classes/LaunchReviewPlugin.m
+++ b/ios/Classes/LaunchReviewPlugin.m
@@ -24,9 +24,9 @@
         } else {
             NSString *iTunesLink;
             if ([call.arguments[@"write_review"] boolValue]) {
-              iTunesLink = [NSString stringWithFormat:@"itms-apps://itunes.apple.com/app/id%@?action=write-review", appId];
+              iTunesLink = [NSString stringWithFormat:@"https://itunes.apple.com/app/id%@?action=write-review", appId];
             } else {
-              iTunesLink = [NSString stringWithFormat:@"itms-apps://itunes.apple.com/app/id%@", appId];
+              iTunesLink = [NSString stringWithFormat:@"https://itunes.apple.com/app/id%@", appId];
             }
 
             NSURL* itunesURL = [NSURL URLWithString:iTunesLink];


### PR DESCRIPTION
`https~` link is recommended as written here. 

> In addition, you can continue to include a persistent link in the settings or configuration screens of your app that deep-links to your App Store product page. To automatically open a page on which users can write a review in the App Store, append the query parameter action=write-review to your product URL.
> 
> https://developer.apple.com/documentation/storekit/skstorereviewcontroller/2851536-requestreview

And, without adding LSApplicationQueriesSchemes - itms, it works fine.