### PR TITLE
Adjust Future<void> to LaunchReview.launch and fix 'Empty app id' exception even it is not empty.

### DIFF
--- a/ios/Classes/LaunchReviewPlugin.m
+++ b/ios/Classes/LaunchReviewPlugin.m
@@ -11,7 +11,7 @@
 
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
     if ([@"launch" isEqualToString:call.method]) {
-        NSString *appId = call.arguments[@"ios_id"] ?? [self fetchAppIdFromBundleId];
+        NSString *appId = call.arguments[@"ios_id"] ? : [self fetchAppIdFromBundleId];
 
         if (appId == (NSString *)[NSNull null]) {
             result([FlutterError errorWithCode:@"ERROR"

--- a/ios/Classes/LaunchReviewPlugin.m
+++ b/ios/Classes/LaunchReviewPlugin.m
@@ -11,7 +11,7 @@
 
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
     if ([@"launch" isEqualToString:call.method]) {
-        NSString *appId = call.arguments[@"ios_id"] ? [self fetchAppIdFromBundleId] : @"";
+        NSString *appId = call.arguments[@"ios_id"] ?? [self fetchAppIdFromBundleId];
 
         if (appId == (NSString *)[NSNull null]) {
             result([FlutterError errorWithCode:@"ERROR"

--- a/lib/launch_review.dart
+++ b/lib/launch_review.dart
@@ -6,7 +6,7 @@ class LaunchReview {
   /// Note: It will not work with the iOS Simulator.
   ///
   /// Set writeReview to false to only show the app store page. Used only in iOS.
-  static void launch(
+  static Future<void> launch(
       {String androidAppId,
       String iOSAppId,
       bool writeReview = true,


### PR DESCRIPTION
1. `'await' applied to 'void', which is not a 'Future'` from Dart Analysis when I call `await LaunchReview.launch(...)`

2. `Empty app id` exception even though app id is not empty on iOS.