### PR TITLE
add required namespace

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'com.iyaffle.launchreview'
     compileSdkVersion 28
 
     defaultConfig {


### PR DESCRIPTION
add namespace to build.gradle as this is now required after the recent change in gradle syntax. pls merge.